### PR TITLE
Command Improvements, various bug fixes and improvements

### DIFF
--- a/src/main/java/com/philderbeast/prisonpicks/Events.java
+++ b/src/main/java/com/philderbeast/prisonpicks/Events.java
@@ -74,8 +74,14 @@ public class Events implements Listener {
             || item.getItemMeta().getLore().contains(ChatColor.LIGHT_PURPLE + "Pick o'Plenty")
             || item.getItemMeta().getLore().contains(ChatColor.GOLD + "Explosive" + ChatColor.LIGHT_PURPLE + " Pick o'Plenty"))
             && item.getDurability() > 0)
-            {
-            player.sendMessage((Object)ChatColor.GOLD + "[Pickaxe Repaired]");
+        {
+            if (item.getItemMeta().getLore().contains(ChatColor.LIGHT_PURPLE + "Pick o'Plenty")) {
+                player.sendMessage(ChatColor.LIGHT_PURPLE + "[Pickaxe Repaired]");
+            } else if (item.getItemMeta().getLore().contains(ChatColor.GOLD + "Explosive" + ChatColor.LIGHT_PURPLE + " Pick o'Plenty")) {
+                player.sendMessage(ChatColor.AQUA + "[Pickaxe Repaired]");
+            } else {
+                player.sendMessage(ChatColor.GOLD + "[Pickaxe Repaired]");
+            }
             short s = 0;
             item.setDurability(s);
         }

--- a/src/main/java/com/philderbeast/prisonpicks/Pick.java
+++ b/src/main/java/com/philderbeast/prisonpicks/Pick.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.enchantments.Enchantment;
@@ -138,7 +139,7 @@ public class Pick{
         }
 
         if (noInventorySpace && !PrisonPicks.getInstance().getDisabledAlerts().contains(player.getName())) {
-            player.playSound(player.getLocation(), Sound.BLOCK_NOTE_PLING, 1.0f, 1.0f);
+            player.playSound(player.getLocation(), Sound.BLOCK_NOTE_PLING, SoundCategory.BLOCKS, 1.0f, 1.0f);
             player.sendTitle(ChatColor.RED + "Inventory is Full!", ChatColor.GOLD + "/fullnotify to disable", 1, 15, 5);
         }
 

--- a/src/main/java/com/philderbeast/prisonpicks/PrisonPicks.java
+++ b/src/main/java/com/philderbeast/prisonpicks/PrisonPicks.java
@@ -58,11 +58,13 @@ public class PrisonPicks extends JavaPlugin {
                             {
                                 receiver.getInventory().addItem(pick);
                                 receiver.updateInventory();
-                                receiver.sendMessage(ChatColor.GOLD + "[Added an Explosive Pickaxe to your Inventory]");
-                                sender.sendMessage(ChatColor.GREEN + "Pickaxe Sent");
+                                receiver.sendMessage(ChatColor.GOLD + "[Added a Explosive Pickaxe to your Inventory]");
+                                sender.sendMessage(ChatColor.GREEN + "[Explosive Pickaxe sent to " + receiver.getName() + "]");
                             }else
                             {
                                 receiver.getWorld().dropItemNaturally(receiver.getLocation(), pick);
+                                receiver.sendMessage(ChatColor.RED + "[Your inventory is full! Explosive Pickaxe has been dropped!]");
+                                sender.sendMessage(ChatColor.YELLOW + "[" + receiver.getName() + "'s inventory was full! Explosive Pickaxe was dropped.]");
                             }
                         break;
                         case "pickoplenty":
@@ -71,11 +73,13 @@ public class PrisonPicks extends JavaPlugin {
                             {
                                 receiver.getInventory().addItem(pick);
                                 receiver.updateInventory();
-                                receiver.sendMessage(ChatColor.GOLD + "[Added an Pick o'Plenty to your Inventory]");
-                                sender.sendMessage(ChatColor.GREEN + "Pickaxe Sent");
+                                receiver.sendMessage(ChatColor.GOLD + "[Added a Pick o'Plenty to your Inventory]");
+                                sender.sendMessage(ChatColor.GREEN + "[Pick o'Plenty sent to " + receiver.getName() + "]");
                             }else
                             {
                                 receiver.getWorld().dropItemNaturally(receiver.getLocation(), pick);
+                                receiver.sendMessage(ChatColor.RED + "[Your inventory is full! Pick o'Plenty has been dropped!]");
+                                sender.sendMessage(ChatColor.YELLOW + "[" + receiver.getName() + "'s inventory was full! Pick o'Plenty was dropped.]");
                             }
                         break;
                         case "xpickoplenty":
@@ -84,32 +88,43 @@ public class PrisonPicks extends JavaPlugin {
                             {
                                 receiver.getInventory().addItem(pick);
                                 receiver.updateInventory();
-                                receiver.sendMessage(ChatColor.GOLD + "[Added an Explosive Pick o'Plenty to your Inventory]");
-                                sender.sendMessage(ChatColor.GREEN + "Pickaxe Sent");
+                                receiver.sendMessage(ChatColor.GOLD + "[Added a Explosive Pick o'Plenty to your Inventory]");
+                                sender.sendMessage(ChatColor.GREEN + "[Explosive Pick o'Plenty sent to " + receiver.getName() + "]");
                             }else
                             {
                                 receiver.getWorld().dropItemNaturally(receiver.getLocation(), pick);
+                                receiver.sendMessage(ChatColor.RED + "[Your inventory is full! Explosive Pick o'Plenty has been dropped!]");
+                                sender.sendMessage(ChatColor.YELLOW + "[" + receiver.getName() + "'s inventory was full! Explosive Pick o'Plenty was dropped.]");
                             }
                         break;
                         case "fakexpickoplenty":
                             pick = Util.createItemStack(Material.DIAMOND_PICKAXE, 1, "", ChatColor.GREEN + "Explosive Pick o'Plenty");
+                            sender.sendMessage(ChatColor.YELLOW + "[" + receiver.getName() + "'s inventory was full! Explosive pickaxe was dropped.]");
                             
                             if( Util.isSpaceAvailable(receiver, pick))
                             {
                                 receiver.getInventory().addItem(pick);
                                 receiver.updateInventory();
-                                receiver.sendMessage(ChatColor.GOLD + "[Added an Explosive Pick o'Plenty to your Inventory]");
-                                sender.sendMessage(ChatColor.GREEN + "Pickaxe Sent");
+                                receiver.sendMessage(ChatColor.GOLD + "[Added a Explosive Pick o'Plenty to your Inventory]");
+                                sender.sendMessage(ChatColor.GREEN + "[Explosive Pick o'Plenty sent to " + receiver.getName() + "]");
                             }else
                             {
                                 receiver.getWorld().dropItemNaturally(receiver.getLocation(), pick);
+                                receiver.sendMessage(ChatColor.RED + "[Your inventory is full! Explosive Pick o'Plenty has been dropped!]");
+                                sender.sendMessage(ChatColor.YELLOW + "[" + receiver.getName() + "'s inventory was full! Explosive Pick o'Plenty was dropped.]");
                             }
                         break;
                         default:
+                            sender.sendMessage(ChatColor.RED + "Invalid pickaxe type!" + ChatColor.GOLD + " Available options: explosive, pickoplenty, xpickoplenty, fakexpickoplenty");
                             sender.sendMessage(ChatColor.RED + "Usage: /pick [type] [player]");
                         break;
                     }
+                } else {
+                    sender.sendMessage(ChatColor.RED + "Could not find player '" + args[1] + "'");
+                    sender.sendMessage(ChatColor.RED + "Usage: /pick [type] [player]");
                 }
+            } else {
+                sender.sendMessage(ChatColor.RED + "Usage: /pick [type] [player]");
             }
         }
 

--- a/src/main/java/com/philderbeast/prisonpicks/Util.java
+++ b/src/main/java/com/philderbeast/prisonpicks/Util.java
@@ -93,7 +93,7 @@ public class Util {
         boolean space = false;
         for (int i = 0; i <= 35; i++) {
             ItemStack slotItem = player.getInventory().getItem(i);
-            if (slotItem == null || ((slotItem.getType() == item.getType()) && item.getAmount() + slotItem.getAmount() <= player.getInventory().getMaxStackSize())) {
+            if (slotItem == null || (slotItem.getType() == item.getType() && item.getAmount() + slotItem.getAmount() <= slotItem.getMaxStackSize())) {
                 space = true;
             }
         }


### PR DESCRIPTION
Added proper checking on command parameters to help users who may accidentally type the command wrong. Instead of saying nothing we now tell them the error and show the proper command usage.

Fixed a major bug in the full inventory detection. Instead of checking the inventorys max stack size we check the item slots max stack size. This prevents the plugin thinking things such as Diamond Pickaxes (which only can stack to 1) stack to 64. This now works properly for those items and will no longer delete the pickaxe if the player inventory was full and will now drop it on the ground as originally intended. Also added a warning to both the sender and receiver that the item was dropped to the ground as the inventory was full.

Based the "Pickaxe Repaired" chat message color off the pickaxe type just as the original plugin did.

Added the Full Inventory sound to the blocks sound category so the volume can be adjusted.