### PR TITLE
Fix drop rates being excessive

### DIFF
--- a/src/main/java/com/philderbeast/prisonpicks/Pick.java
+++ b/src/main/java/com/philderbeast/prisonpicks/Pick.java
@@ -5,7 +5,9 @@ import java.util.HashMap;
 import java.util.Random;
 import java.util.Collection;
 import java.util.ArrayList;
-import net.md_5.bungee.api.ChatColor;
+import java.util.Iterator;
+
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
@@ -102,7 +104,9 @@ public class Pick{
 
                     Collection<ItemStack> blocks = new ArrayList<>();
 
-                    for (ItemStack newItem : stacks) {
+                    Iterator itr = stacks.iterator();
+                    if (itr.hasNext()) {
+                        ItemStack newItem = (ItemStack) itr.next();
 
                         if (enchants.get(FORTUNE)) {
                             int fortune = item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS);
@@ -120,9 +124,7 @@ public class Pick{
                                     player.getInventory().addItem(is);
                                 }
                             }
-                        
-                        }else {
-
+                        } else {
                             if (Util.isSpaceAvailable(player, newItem)) {
                                 player.getInventory().addItem(newItem);
                             } else {


### PR DESCRIPTION
This fixes a bad loop which causes us to have excessive drop rates on blocks which have multiple drops such as Lapis and Redstone