### PR TITLE
Implemented custom prison-picks WorldGuard flag

### DIFF
--- a/src/main/java/com/philderbeast/prisonpicks/Pickoplenty.java
+++ b/src/main/java/com/philderbeast/prisonpicks/Pickoplenty.java
@@ -27,7 +27,7 @@ public class Pickoplenty extends Pick{
         Block block = event.getBlock();
 
         if (!block.hasMetadata("blockBreaker") 
-            && PrisonPicks.canBuild(player, block.getLocation())) 
+            && PrisonPicks.canBuild(player, block.getLocation()))
         {
             Location center = event.getBlock().getLocation();
             int radius = 2;

--- a/src/main/java/com/philderbeast/prisonpicks/PrisonPicks.java
+++ b/src/main/java/com/philderbeast/prisonpicks/PrisonPicks.java
@@ -1,11 +1,15 @@
 package com.philderbeast.prisonpicks;
 
+import com.sk89q.worldguard.bukkit.BukkitUtil;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.StateFlag;
 
 import me.MnMaxon.AutoPickup.AutoPickupPlugin;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -13,13 +17,32 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class PrisonPicks extends JavaPlugin {
 
     private static PrisonPicks instance;
+    private static final StateFlag prisonPickFlag = new StateFlag("prison-picks", true);
 
+    @Override
+    public void onLoad() {
+        WorldGuardPlugin worldGuard = getWorldGuard();
+
+        if (worldGuard != null) {
+            try {
+                worldGuard.getFlagRegistry().register(prisonPickFlag);
+                this.getLogger().info("prison-picks custom WorldGuard flag has been registered");
+            } catch (Exception e) {
+                this.getLogger().severe("Unable to register flag! Are you running at least WorldGuard 6.1.3?");
+                e.printStackTrace();
+                this.onDisable();
+            }
+        }
+    }
+
+    @Override
     public void onEnable() {
         instance = this;
         this.getServer().getPluginManager().registerEvents(new Events(this),this);
         this.getCommand("pick").setExecutor(new PickCommands());
     }
 
+    @Override
     public void onDisable() {
     }
 
@@ -41,8 +64,11 @@ public class PrisonPicks extends JavaPlugin {
         WorldGuardPlugin wg = PrisonPicks.getWorldGuard();
         if(wg != null)
         {
-            return wg.canBuild(player, location);
-        }else {
+            World world = location.getWorld();
+            ApplicableRegionSet regions = wg.getRegionManager(world).getApplicableRegions(BukkitUtil.toVector(location));
+
+            return wg.canBuild(player, location) && regions.testState(null,  prisonPickFlag);
+        } else {
             return true;
         }
     }

--- a/src/main/java/com/philderbeast/prisonpicks/XPickoPlenty.java
+++ b/src/main/java/com/philderbeast/prisonpicks/XPickoPlenty.java
@@ -29,7 +29,7 @@ public class XPickoPlenty extends Pick{
     public void breakBlock(BlockBreakEvent event)
     {
         Player player = event.getPlayer();
-        ArrayList<Location> locations = new  ArrayList<Location>();
+        ArrayList<Location> locations = new  ArrayList<>();
         ItemStack item = player.getInventory().getItemInMainHand();
 
         if (PrisonPicks.canBuild(player, event.getBlock().getLocation()))

--- a/src/main/java/com/philderbeast/prisonpicks/Xpick.java
+++ b/src/main/java/com/philderbeast/prisonpicks/Xpick.java
@@ -25,7 +25,7 @@ public class Xpick extends Pick {
     public void breakBlock(BlockBreakEvent event)
     {
         Player player = event.getPlayer();
-        ArrayList<Location> locations = new  ArrayList<Location>();
+        ArrayList<Location> locations = new  ArrayList<>();
         ItemStack item = player.getInventory().getItemInMainHand();
 
         if (PrisonPicks.canBuild(player, event.getBlock().getLocation()))
@@ -53,7 +53,7 @@ public class Xpick extends Pick {
                         double distance = (bX - x) * (bX - x) + (bZ - z) * (bZ - z) + (bY - y) * (bY - y);
                         Location block = new Location(center.getWorld(), (double)x, (double)y, (double)z);
                         if (distance < (double)(radius * radius) 
-                                && PrisonPicks.canBuild(player, block) 
+                                && PrisonPicks.canBuild(player, block)
                                 && (!block.equals(centerloc))
                                 && (block.getBlock().getType() != Material.BEDROCK)
                                 && (block.getBlock().getType() != Material.AIR)) {


### PR DESCRIPTION
Uses a new custom registered prison-picks StateFlag to determine whether the picks should be allowed in the region. This flag defaults to true. If a region does not specify this flag as 'deny', prisonPicks will work in the region.